### PR TITLE
Use $KIPRJMOD for relative paths

### DIFF
--- a/hardware/orangecrab_r0.1/OrangeCrab.kicad_pcb
+++ b/hardware/orangecrab_r0.1/OrangeCrab.kicad_pcb
@@ -1571,7 +1571,7 @@
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
     )
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_housings_bga.3dshapes/csBGA285.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_housings_bga.3dshapes/csBGA285.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -1745,7 +1745,7 @@
       (net 13 JTAG_TMS))
     (pad 1 smd rect (at 2.54 -2 270) (size 0.74 2.8) (layers F.Cu F.Paste F.Mask)
       (net 65 P3.3V))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/FTSH-105-01-L-DV-K-TR.stp
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/FTSH-105-01-L-DV-K-TR.stp
       (offset (xyz 0 0 0.4))
       (scale (xyz 1 1 1))
       (rotate (xyz -90 0 180))
@@ -2055,7 +2055,7 @@
       (net 1 GND))
     (pad 6 smd rect (at -2.9 1.2375 270) (size 1.2 1.9) (layers F.Cu F.Mask)
       (net 1 GND))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/10118194c_usb_microb.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/10118194c_usb_microb.step
       (offset (xyz 0 -1.25 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -2113,7 +2113,7 @@
       (net 144 VBATT))
     (pad 1 smd roundrect (at -1 0.5) (size 1 4) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 1 GND))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/S2B-PH-SM4-TB.STEP
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/S2B-PH-SM4-TB.STEP
       (offset (xyz 0 2 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 180))
@@ -3374,7 +3374,7 @@
       (net 143 "Net-(D1-Pad4)"))
     (pad 3 smd roundrect (at 0.325 -0.325 180) (size 0.4 0.4) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 142 "Net-(D1-Pad3)"))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -3403,7 +3403,7 @@
       (net 128 "Net-(D2-Pad4)"))
     (pad 3 smd roundrect (at 0.325 -0.325 180) (size 0.4 0.4) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 123 "Net-(D2-Pad3)"))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -3526,7 +3526,7 @@
       (net 8 FPGA_RESET))
     (pad 2 smd rect (at -2.075 1.075 90) (size 1.05 0.65) (layers F.Cu F.Paste F.Mask)
       (net 8 FPGA_RESET))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_misc.3dshapes/TL3365AF180QG.stp
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_misc.3dshapes/TL3365AF180QG.stp
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -3628,7 +3628,7 @@
       (net 43 REF_CLK) (solder_paste_margin -0.08))
     (pad 2 smd roundrect (at 1.024999 0.725 270) (size 0.8 0.9) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 1 GND) (solder_paste_margin -0.08))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_time.3dshapes/TXO_2.5x2.0mm.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_time.3dshapes/TXO_2.5x2.0mm.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -4044,7 +4044,7 @@
       (net 132 SD0_DAT3))
     (pad 1 smd roundrect (at 3.55 -4.075 90) (size 0.5 1) (layers B.Cu B.Paste B.Mask) (roundrect_rratio 0.2)
       (net 130 SD0_DAT2))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/1051620001.stp
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/1051620001.stp
       (offset (xyz 0 0 0.27))
       (scale (xyz 1 1 1))
       (rotate (xyz -90 0 0))
@@ -5068,7 +5068,7 @@
       ))
     (pad 2 smd rect (at 0 0 45) (size 0.58 0.58) (layers F.Cu F.Paste F.Mask)
       (net 1 GND) (solder_mask_margin -0.05) (solder_paste_margin -0.08))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_housings_bga.3dshapes/xson-4.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_housings_bga.3dshapes/xson-4.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))

--- a/hardware/orangecrab_r0.2/OrangeCrab.kicad_pcb
+++ b/hardware/orangecrab_r0.2/OrangeCrab.kicad_pcb
@@ -982,12 +982,12 @@
       (net 118 SD0_DAT3))
     (pad 1 smd rect (at 3.105 0 90) (size 0.75 1.1) (layers B.Cu B.Paste B.Mask)
       (net 116 SD0_DAT2))
-    (model ${KIPRJMOD}../../lib/gkl/3d/1040310811.stp
+    (model ${KIPRJMOD}/../../lib/gkl/3d/1040310811.stp
       (offset (xyz -1130.299983024597 182.879997253418 15.23999977111816))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
     )
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/MicroSD.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/MicroSD.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -1627,7 +1627,7 @@
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
     )
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_housings_bga.3dshapes/csBGA285.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_housings_bga.3dshapes/csBGA285.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -2759,7 +2759,7 @@
       (net 13 JTAG_TMS))
     (pad 1 smd rect (at 2.54 -2 270) (size 0.74 2.8) (layers F.Cu F.Paste F.Mask)
       (net 64 P3.3V))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/FTSH-105-01-L-DV-K-TR.stp
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/FTSH-105-01-L-DV-K-TR.stp
       (offset (xyz 0 0 0.4))
       (scale (xyz 1 1 1))
       (rotate (xyz -90 0 180))
@@ -2985,7 +2985,7 @@
       (net 1 GND))
     (pad 6 smd rect (at -2.9 1.2375 270) (size 1.2 1.9) (layers F.Cu F.Mask)
       (net 1 GND))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/10118194c_usb_microb.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/10118194c_usb_microb.step
       (offset (xyz 0 -1.25 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -3043,7 +3043,7 @@
       (net 128 VBATT))
     (pad 1 smd roundrect (at -1 0.5) (size 1 4) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 1 GND))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_conn.3dshapes/S2B-PH-SM4-TB.STEP
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_conn.3dshapes/S2B-PH-SM4-TB.STEP
       (offset (xyz 0 2 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 180))
@@ -4166,7 +4166,7 @@
       (net 127 "Net-(D1-Pad4)"))
     (pad 3 smd roundrect (at 0.325 -0.325 180) (size 0.4 0.4) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 126 "Net-(D1-Pad3)"))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -4195,7 +4195,7 @@
       (net 114 "Net-(D2-Pad4)"))
     (pad 3 smd roundrect (at 0.325 -0.325 180) (size 0.4 0.4) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 109 "Net-(D2-Pad3)"))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_led.3dshapes/XZxxxxxx150W.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -4261,7 +4261,7 @@
       (net 148 USER_BUTTON))
     (pad 2 smd rect (at -2.075 1.075 90) (size 1.05 0.65) (layers F.Cu F.Paste F.Mask)
       (net 148 USER_BUTTON))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_misc.3dshapes/TL3365AF180QG.stp
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_misc.3dshapes/TL3365AF180QG.stp
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))
@@ -4363,7 +4363,7 @@
       (net 43 REF_CLK) (solder_paste_margin -0.08))
     (pad 2 smd roundrect (at 1.024999 0.725 90) (size 0.8 0.9) (layers F.Cu F.Paste F.Mask) (roundrect_rratio 0.25)
       (net 1 GND) (solder_paste_margin -0.08))
-    (model /home/greg/projects/OrangeCrab/lib/gkl/packages3d/gkl_time.3dshapes/TXO_2.5x2.0mm.step
+    (model ${KIPRJMOD}/../../lib/gkl/packages3d/gkl_time.3dshapes/TXO_2.5x2.0mm.step
       (at (xyz 0 0 0))
       (scale (xyz 1 1 1))
       (rotate (xyz 0 0 0))


### PR DESCRIPTION
Fixes 3D model paths so that the 3D view works for non-Gregs :)

Before:
![image](https://user-images.githubusercontent.com/14631/72412936-75ebeb80-3723-11ea-9158-8ac577e4a0bf.png)

After:
![image](https://user-images.githubusercontent.com/14631/72412947-7dab9000-3723-11ea-89bd-12203a334a73.png)

There is still a model that doesn't show up for U10 because `${KISYS3DMOD}/Package_SON.3dshapes/Texas_X2SON-4_1x1mm_P0.65mm.wrl` doesn't seem to be in https://github.com/KiCad/kicad-packages3D/tree/master/Package_SON.3dshapes

![image](https://user-images.githubusercontent.com/14631/72413018-ac296b00-3723-11ea-9b1a-e709b5a64adb.png)

@gregdavill does this one show up for you?