### PR TITLE
Make gateware examples more compatible with R1

### DIFF
--- a/gateware/litex_ddr3_test/OrangeCrab-bitstream.py
+++ b/gateware/litex_ddr3_test/OrangeCrab-bitstream.py
@@ -93,9 +93,7 @@ class DDR3TestSoC(SoCSDRAM):
         "analyzer":  17
     }
     csr_map.update(SoCSDRAM.csr_map)
-    def __init__(self, toolchain="diamond"):
-        platform = OrangeCrab_r1.Platform(toolchain=toolchain)
-        
+    def __init__(self, platform):
         sys_clk_freq = int(48e6)
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
                           cpu_type=None, l2_size=32,
@@ -154,8 +152,7 @@ class BaseSoC(SoCSDRAM):
         "ddrphy":    16,
     }
     csr_map.update(SoCSDRAM.csr_map)
-    def __init__(self, toolchain="diamond", **kwargs):
-        platform = OrangeCrab.Platform(toolchain=toolchain)
+    def __init__(self, platform, **kwargs):
         sys_clk_freq = int(48e6)
         SoCSDRAM.__init__(self, platform, clk_freq=sys_clk_freq,
                           cpu_type="vexriscv",
@@ -189,8 +186,7 @@ class BaseSoC(SoCSDRAM):
 
 class LED(SoCCore):
     
-    def __init__(self, toolchain="diamond", **kwargs):
-        platform = OrangeCrab.Platform(toolchain=toolchain)
+    def __init__(self, platform, **kwargs):
         sys_clk_freq = int(10e6)
     
         SoCCore.__init__(self, platform, clk_freq=sys_clk_freq,
@@ -241,16 +237,19 @@ def main():
 
     toolchain = "trellis"
     toolchain_path = "/usr/share/trellis"
-
+    if "r1" in sys.argv[1:]:
+        platform = OrangeCrab_r1.Platform(toolchain=toolchain)
+    else:
+        platform = OrangeCrab.Platform(toolchain=toolchain)
 
     if "ddr3_test" in sys.argv[1:]:
-        soc = DDR3TestSoC(toolchain=toolchain)
+        soc = DDR3TestSoC(platform=platform)
     elif "base" in sys.argv[1:]:
-        soc = BaseSoC(toolchain=toolchain)
+        soc = BaseSoC(platform=platform)
     elif "bist" in sys.argv[1:]:
-        soc = BISTSoC(toolchain=toolchain)
+        soc = BISTSoC(platform=platform)
     elif "led" in sys.argv[1:]:
-        soc = LED(toolchain=toolchain)
+        soc = LED(platform=platform)
     else:
         print("missing target, supported: (ddr3_test, base, ethernet, bist)")
         exit(1)

--- a/gateware/litex_ddr3_test/OrangeCrab-bitstream.py
+++ b/gateware/litex_ddr3_test/OrangeCrab-bitstream.py
@@ -201,22 +201,35 @@ class LED(SoCCore):
 
         
         led = platform.request("rgb_led", 0)
-        btn = platform.request("usr_btn", 0)
+        try:
+            btn = platform.request("usr_btn", 0)
+        except:
+            btn = None
+
         # led blinking
         led_counter = Signal(32)
-        latch = Signal(32)
-        self.sync += [
-            If(latch == 0xFFFF0000,
+        if btn is not None:
+            latch = Signal(32)
+            self.sync += [
+                If(latch == 0xFFFF0000,
+                    led_counter.eq(led_counter + 1)
+                ),
+                latch.eq(Cat(btn,latch[0:31]))
+            ]
+            self.comb += [
+                led.r.eq(~led_counter[0]),
+                led.g.eq(~led_counter[1]),
+                led.b.eq(~led_counter[2]),
+            ]
+        else:
+            self.sync += [
                 led_counter.eq(led_counter + 1)
-            ),
-            latch.eq(Cat(btn,latch[0:31]))
-            
-        ]
-        self.comb += [
-            led.r.eq(~led_counter[0]),
-            led.g.eq(~led_counter[1]),
-            led.b.eq(~led_counter[2]),
-        ]
+            ]
+            self.comb += [
+                led.r.eq(~led_counter[22]),
+                led.g.eq(~led_counter[23]),
+                led.b.eq(~led_counter[24]),
+            ]
 
 
 # BISTSoC --------------------------------------------------------------------------------------

--- a/gateware/litex_ddr3_test/OrangeCrab_r1.py
+++ b/gateware/litex_ddr3_test/OrangeCrab_r1.py
@@ -12,13 +12,16 @@ _io = [
     #("rst_n", 0, Pins("R16"), IOStandard("LVCMOS25")),
 
     ("user_led", 0, Pins("V17"), IOStandard("LVCMOS25")),
-    ("user_led", 1, Pins("T17"), IOStandard("LVCMOS25")),
-    ("user_led", 2, Pins("J3"), IOStandard("LVCMOS25")),
 
+    ("rgb_led", 0,
+        Subsignal("r", Pins("V17"), IOStandard("LVCMOS33")),
+        Subsignal("g", Pins("T17"), IOStandard("LVCMOS33")),
+        Subsignal("b", Pins("J3"), IOStandard("LVCMOS33")),
+    ),
 
     ("serial", 0,
-        Subsignal("tx", Pins("N17"), IOStandard("LVCMOS25")),
-        Subsignal("rx", Pins("M18"), IOStandard("LVCMOS25")),
+        Subsignal("tx", Pins("N17"), IOStandard("LVCMOS33")),
+        Subsignal("rx", Pins("M18"), IOStandard("LVCMOS33")),
     ),
 
     ("ddram", 0,


### PR DESCRIPTION
This adds an option to specify the platform version when building, and makes the LED example compatible with R1.