### PR TITLE
Add kitspace.yaml

### DIFF
--- a/kitspace.yaml
+++ b/kitspace.yaml
@@ -1,0 +1,15 @@
+multi:
+  OrangeCrab-r0.1:
+    color: orange
+    readme: hardware/orangecrab_r0.1/README.md
+    bom: hardware/orangecrab_r0.1/bom/OrangeCrab.csv
+    eda:
+      type: kicad
+      pcb: hardware/orangecrab_r0.1/OrangeCrab.kicad_pcb
+  OrangeCrab-r0.2:
+    color: orange
+    readme: hardware/orangecrab_r0.2/README.md
+    bom: hardware/orangecrab_r0.2/Production/OrangeCrab-r0.2-bom.csv
+    eda:
+      type: kicad
+      pcb: hardware/orangecrab_r0.2/OrangeCrab.kicad_pcb


### PR DESCRIPTION
Hey, this adds a kitspace.yaml file to allow this repo to be listed on [kitspace.org](https://kitspace.org). Here is [a preview](http://add-orange-crab.preview.kitspace.org/). 

The idea for Kitspace is to make it easier for people to buy the parts to re-build projects. I built a browser extension that adds parts to shopping carts. Right now that only works if you actually put in distributor SKUs in the BOM but I am working on making that work for MPNs as well, so it should work better for your BOMs in the future.  

Instead of letting Kitspace plot the Gerbers for you (though that's actually using [a script derived from one of your scripts](https://github.com/kitspace/kitspace/blob/6074ae501c16d9fe59359d351197ff336640232f/tasks/page/plot_kicad_gerbers)) you could also unzip them and point to them using `gerbers: ` in the kitspace.yaml.

Anyway, if you are happy to add it, then just merge this. The Kitspace pages will then be put up and stay in sync with this repo in the future (though there can be a lag of up to 24hrs). 